### PR TITLE
Centrifuge related changes

### DIFF
--- a/biopet.wdl
+++ b/biopet.wdl
@@ -12,8 +12,8 @@ task BaseCounter {
 
     Float? memory
     Float? memoryMultiplier
-
     Int mem = ceil(select_first([memory, 12.0]))
+
     command {
         set -e -o pipefail
         mkdir -p ${outputDir}
@@ -72,7 +72,7 @@ task FastqSplitter {
     File inputFastq
     String outputPath
     Int numberChunks
-    String tool_jar
+    File toolJar
     Array[Int] chunks = range(numberChunks)
 
     command {
@@ -81,7 +81,7 @@ task FastqSplitter {
         mkdir -p ${sep=' ' prefix(outputPath + "/chunk_", chunks)}
         if [ ${numberChunks} -gt 1 ]; then
             SEP="/${basename(inputFastq)} -o "
-            java -jar ${tool_jar} -I ${inputFastq} -o ${sep='$SEP' prefix(outputPath + "/chunk_", chunks)}/${basename(inputFastq)}
+            java -jar ${toolJar} -I ${inputFastq} -o ${sep='$SEP' prefix(outputPath + "/chunk_", chunks)}/${basename(inputFastq)}
         else
             ln -sf ${inputFastq} ${outputPath}/chunk_0/${basename(inputFastq)}
         fi
@@ -100,12 +100,13 @@ task FastqSync {
     File in2
     String out1path
     String out2path
-    File tool_jar
+    File toolJar
+
     command {
         set -e -o pipefail
         ${preCommand}
         mkdir -p $(dirname ${out1path}) $(dirname ${out2path})
-        java -jar ${tool_jar} \
+        java -jar ${toolJar} \
         --in1 ${in1} \
         --in2 ${in2} \
         --ref1 ${ref1} \
@@ -113,6 +114,7 @@ task FastqSync {
         --out1 ${out1path} \
         --out2 ${out2path}
     }
+
     output {
         File out1 = out1path
         File out2 = out2path
@@ -121,7 +123,7 @@ task FastqSync {
 
 task SampleConfig {
     String? preCommand
-    String tool_jar
+    File toolJar
     Array[File]+ inputFiles
     String keyFilePath
     String? sample
@@ -132,13 +134,13 @@ task SampleConfig {
 
     Float? memory
     Float? memoryMultiplier
-
     Int mem = ceil(select_first([memory, 4.0]))
+
     command {
         set -e -o pipefail
         ${preCommand}
         mkdir -p . ${"$(dirname " + jsonOutputPath + ")"} ${"$(dirname " + tsvOutputPath + ")"}
-        java -Xmx${mem}G -jar ${tool_jar} \
+        java -Xmx${mem}G -jar ${toolJar} \
         -i ${sep="-i " inputFiles} \
         ${"--sample " + sample} \
         ${"--library " + library} \
@@ -161,23 +163,23 @@ task SampleConfig {
 
 task ScatterRegions {
     String? preCommand
-    File ref_fasta
-    File ref_dict
+    File refFasta
+    File refDict
     String outputDirPath
-    String tool_jar
+    File toolJar
     Int? scatterSize
     File? regions
 
     Float? memory
     Float? memoryMultiplier
-
     Int mem = ceil(select_first([memory, 4.0]))
+
     command {
         set -e -o pipefail
         ${preCommand}
         mkdir -p ${outputDirPath}
-        java -Xmx${mem}G -jar ${tool_jar} \
-          -R ${ref_fasta} \
+        java -Xmx${mem}G -jar ${toolJar} \
+          -R ${refFasta} \
           -o ${outputDirPath} \
           ${"-s " + scatterSize} \
           ${"-L " + regions}

--- a/centrifuge.wdl
+++ b/centrifuge.wdl
@@ -92,7 +92,7 @@ task Classify {
         ${true="-k" false="" defined(assignments)} ${assignments} \
         ${true="-1" false="-U" defined(read2)} ${sep=',' read1} \
         ${true="-2" false="" defined(read2)} ${sep=',' read2} \
-        ${true="-U" false="" defined(unpairedReads)} ${sep=',' unpairedReads}\
+        ${true="-U" false="" defined(unpairedReads)} ${sep=',' unpairedReads} \
         ${"--report-file " + reportFilePath} \
         ${"--min-hitlen " + minHitLen} \
         ${"--min-totallen " + minTotalLen} \
@@ -179,7 +179,10 @@ task Kreport {
     String? preCommand
     File centrifugeOut
     Boolean inputIsCompressed
-    String kreportFilePath=sub(centrifugeOut, "\\.out$|\\.out\\.gz$", "\\.kreport")
+    String outputDir
+    String? suffix = "kreport"
+    String? prefix = "centrifuge"
+    String kreportFilePath = outputDir + "/" + prefix + "." + suffix
     String indexPrefix
     Boolean? onlyUnique
     Boolean? showZeros


### PR DESCRIPTION
Centrifuge can accept lists of files as input and this mainly addresses that.
In a workflow context this deals with the issue of merging input files (e.g. with multiple `common.concatenateTextFiles` tasks)