### PR TITLE
Fixed -U arg

### DIFF
--- a/centrifuge.wdl
+++ b/centrifuge.wdl
@@ -101,7 +101,7 @@ task Classify {
         ~{true="-k" false="" defined(assignments)} ~{assignments} \
         ~{true="-1" false="-U" defined(read2)} ~{sep=',' read1} \
         ~{true="-2" false="" defined(read2)} ~{sep=',' read2} \
-        ~{true="-U" false="" defined(unpairedReads)} ~{sep=',' unpairedReads} \
+        ~{true="-U" false="" length(select_first([unpairedReads])) > 0} ~{sep=',' unpairedReads} \
         ~{"--report-file " + reportFilePath} \
         ~{"--min-hitlen " + minHitLen} \
         ~{"--min-totallen " + minTotalLen} \


### PR DESCRIPTION
This handles the absence of unpaired reads better, so the task command is properly constructed in gams where unpairedReads might not be defined (or defined as an empty array).