### PR TITLE
fixed fastqc call-caching

### DIFF
--- a/fastqc.wdl
+++ b/fastqc.wdl
@@ -21,10 +21,10 @@ task Fastqc {
     }
 
     # Chops of the .gz extension if present.
-    String name = sub(seqFile, "\.gz$","")
+    String name = basename(sub(seqFile, "\.gz$","")) # The Basename needs to be taken here. Otherwise paths might differ between similar jobs.
     # This regex chops of the extension and replaces it with _fastqc for the reportdir.
     # Just as fastqc does it.
-    String reportDir = outdirPath + "/" + sub(basename(name), "\.[^\.]*$", "_fastqc")
+    String reportDir = outdirPath + "/" + sub(name, "\.[^\.]*$", "_fastqc")
 
     command {
         set -e -o pipefail


### PR DESCRIPTION
The variable name differed between runs, because it contained some execution folder specific stuff. This let the call-caching to fail every time.
I fixed it with a comment telling why the fix was made.

The change was tested and confirmed to fix the problem.