### PR TITLE
Saner input for cutadapt

### DIFF
--- a/cutadapt.wdl
+++ b/cutadapt.wdl
@@ -1,10 +1,9 @@
 version 1.0
 
-import "common.wdl"
-
 task Cutadapt {
     input {
-        FastqPair inputFastq
+        File read1
+        File? read2
         String read1output
         String? read2output
         String? format
@@ -120,16 +119,14 @@ task Cutadapt {
         ~{true="--bwa" false="" bwa} \
         ~{true="--zero-cap" false="" zeroCap} \
         ~{true="--no-zero-cap" false="" noZeroCap} \
-        ~{inputFastq.R1} \
-        ~{inputFastq.R2} \
+        ~{read1} \
+        ~{read2} \
         ~{"> " + reportPath}
     }
 
     output{
-        FastqPair cutOutput = object {
-          R1: read1output,
-          R2: read2output
-        }
+        File cutRead1 = read1output
+        File? cutRead2 = read2output
         File report = if defined(reportPath) then select_first([reportPath]) else stdout()
         File? tooLongOutput=tooLongOutputPath
         File? tooShortOutput=tooShortOutputPath


### PR DESCRIPTION
It is ridiculous to use some sort of struct with md5 support where we instead can use a simple read1 and read2. Especially since we do not use the md5s here.

This removes an import from the task, so it can be used as a standalone file by other users.