### PR TITLE
Add flags to varDict filtering script "var2vcf_paired.pl"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ that users understand how the changes affect the new version.
 
 version 1.0.0-dev
 ---------------------------
++ VarDict: Add user definable flags (-M, -A, -Q, -d, -v, -f) to the paired VCF filtering script.
 + Cutadapt: If the output is a gzipped file, compress with level 1 (instead of default 6).
 + Cutadapt: Fix issues with read2output when using single-end reads.
 + Add feature type, idattr and additional attributes to htseq-count.

--- a/vardict.wdl
+++ b/vardict.wdl
@@ -20,6 +20,11 @@ task VarDict {
         Int endColumn = 3
         Int geneColumn = 4
 
+        Float? mappingQuality = 20
+        Int? minimumTotalDepth = 8
+        Int? minimumVariantDepth = 4
+        Float? minimumAlleleFrequency = 0.02
+
         Int threads = 1
         Int memory = 16
         Float memoryMultiplier = 2.5
@@ -45,6 +50,12 @@ task VarDict {
         ~{true="var2vcf_paired.pl" false="var2vcf_valid.pl" defined(normalBam)} \
         -N "~{tumorSampleName}~{"|" + normalSampleName}" \
         ~{true="" false="-E" defined(normalBam)} \
+        -M \
+        -A \
+        -Q ~{mappingQuality} \
+        -d ~{minimumTotalDepth} \
+        -v ~{minimumVariantDepth} \
+        -f ~{minimumAlleleFrequency} \
         > ~{outputVcf}
     }
 

--- a/vardict.wdl
+++ b/vardict.wdl
@@ -20,10 +20,12 @@ task VarDict {
         Int endColumn = 3
         Int geneColumn = 4
 
-        Float? mappingQuality = 20
-        Int? minimumTotalDepth = 8
-        Int? minimumVariantDepth = 4
-        Float? minimumAlleleFrequency = 0.02
+        Boolean outputCandidateSomaticOnly = true
+        Boolean outputAllVariantsAtSamePosition = true
+        Float mappingQuality = 20
+        Int minimumTotalDepth = 8
+        Int minimumVariantDepth = 4
+        Float minimumAlleleFrequency = 0.02
 
         Int threads = 1
         Int memory = 16
@@ -50,8 +52,8 @@ task VarDict {
         ~{true="var2vcf_paired.pl" false="var2vcf_valid.pl" defined(normalBam)} \
         -N "~{tumorSampleName}~{"|" + normalSampleName}" \
         ~{true="" false="-E" defined(normalBam)} \
-        -M \
-        -A \
+        ~{true="-M" false="" outputCandidateSomaticOnly} \
+        ~{true="-A" false="" outputAllVariantsAtSamePosition} \
         -Q ~{mappingQuality} \
         -d ~{minimumTotalDepth} \
         -v ~{minimumVariantDepth} \


### PR DESCRIPTION
Flag description:
  -M  If set, output only candidate somatic
  -A  Indicate to output all variants at the same position.  By default, only the variant with the highest allele frequency is converted to VCF
  -Q  float The minimum mapping quality.  Defaults to 0 for Illumina sequencing => Using -Q 20 as default
  -d  integer The minimum total depth.  Defaults to 5 => Using -d 8 as default
  -v  integer The minimum variant depth.  Defaults to 3 => Using -v 4 as default
  -f  float The minimum allele frequency.  Defaults to 0.02

Note that "-M" is a soft filter (see https://github.com/AstraZeneca-NGS/VarDictJava/issues/247). This means that there will still be variants with "STATUS=Germline" with a "PASS" filter.
