### PR TITLE
Update fastqsplitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ that users understand how the changes affect the new version.
 
 version 1.0.0-dev
 ---------------------------
++ Fastqsplitter: fix mkdir command to work with biocontainer's busybox mkdir
 + Cutadapt: simplify interface
 + Bigger memory multiplier in mutect to take in account bigger vmem usage
 + Cutadapt: Remove default adapter

--- a/fastqsplitter.wdl
+++ b/fastqsplitter.wdl
@@ -34,9 +34,12 @@ task Fastqsplitter {
         Int cores = 1 + ceil(0.5 * length(outputPaths))
     }
 
+    # Busybox mkdir does not accept multiple paths.
     command <<<
         set -e
-        mkdir -p $(dirname ~{sep=' ' outputPaths})
+        for FILE in ~{sep=' ' outputPaths}
+            do mkdir -p $(dirname $FILE)
+        done
         fastqsplitter \
         ~{"-c " + compressionLevel} \
         ~{"-t " + threadsPerFile} \

--- a/fastqsplitter.wdl
+++ b/fastqsplitter.wdl
@@ -26,7 +26,7 @@ task Fastqsplitter {
     input {
         File inputFastq
         Array[String]+ outputPaths
-        String dockerImage = "quay.io/biocontainers/fastqsplitter:1.1.0--py37h516909a_0"
+        String dockerImage = "quay.io/biocontainers/fastqsplitter:1.1.0--py37h516909a_1"
         Int? compressionLevel
         Int? threadsPerFile
          # fastqplitter utilizes one thread per input file and one or more threads per output file + one thread for the application.
@@ -34,7 +34,7 @@ task Fastqsplitter {
         Int cores = 1 + ceil(0.5 * length(outputPaths))
     }
 
-    command {
+    command <<<
         set -e
         mkdir -p $(dirname ~{sep=' ' outputPaths})
         fastqsplitter \
@@ -42,7 +42,7 @@ task Fastqsplitter {
         ~{"-t " + threadsPerFile} \
         -i ~{inputFastq} \
         -o ~{sep=' -o ' outputPaths}
-    }
+    >>>
 
     output {
         Array[File] chunks = outputPaths


### PR DESCRIPTION
This fixes the mkdir command so it works properly on busybox.
It also updates the container to a slightly newer version. It is still the same version of fastqsplitter, but the xopen dependency was updated for even faster fastq reading.
- [x] Pull request details were added to CHANGELOG.md
