### PR TITLE
BIOWDL-326: Add -k option to minimap2 mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ that users understand how the changes affect the new version.
 
 version 1.1.0-dev
 ---------------------------
++ Minimap2: Add -k option to minimap2 mapping
 + Added bwakit task
 + Minimap2: Add the option for --MD tag
 + TALON: Update average memory needs for main TALON process

--- a/minimap2.wdl
+++ b/minimap2.wdl
@@ -77,6 +77,7 @@ task Mapping {
         String outputPrefix
         String presetOption
         Boolean outputSAM = false
+        Int kmerSize = 15
 
         Int? maxFragmentLength
         Int? maxIntronLength
@@ -101,6 +102,7 @@ task Mapping {
         ~{true="-a" false="" outputSAM} \
         ~{"-G " + maxIntronLength} \
         ~{"-F " + maxFragmentLength} \
+        ~{"-k " + kmerSize} \
         ~{true="-X" false="" skipSelfAndDualMappings} \
         ~{"-N " + retainMaxSecondaryAlignments} \
         ~{"-A " + matchingScore} \
@@ -132,6 +134,7 @@ task Mapping {
         outputSAM: "Output in the SAM format."
         maxFragmentLength: "Max fragment length (effective with -xsr or in the fragment mode)."
         maxIntronLength: "Max intron length (effective with -xsplice; changing -r)."
+        kmerSize: "K-mer size (no larger than 28)."
         skipSelfAndDualMappings: "Skip self and dual mappings (for the all-vs-all mode)."
         retainMaxSecondaryAlignments: "Retain at most INT secondary alignments."
         matchingScore: "Matching score."


### PR DESCRIPTION
Based on minimap2 recommendations, the -k tag should be set to 14 for aligning directRNA Nanopore data

### Checklist
- [x] Pull request details were added to CHANGELOG.md
