### PR TITLE
BIOWDL-386: Centrifuge should use -U instead of -1 with single end data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ that users understand how the changes affect the new version.
 
 version 2.2.0-dev
 ---------------------------
++ Centrifuge: Fix -1/-U options for single end data.
 + Add bedtools.Complement, bedtools.Merge, and add a task to combine multiple
   bed files called bedtools.MergeBedFiles. This task combines bedtools merge 
   and sort.

--- a/centrifuge.wdl
+++ b/centrifuge.wdl
@@ -91,8 +91,8 @@ task Classify {
         Array[File]+ read1
         String outputPrefix
         String outputName = basename(outputPrefix)
+        Array[File] read2 = []
 
-        Array[File]? read2
         Int? trim5
         Int? trim3
         Int? reportMaxDistinct
@@ -121,8 +121,8 @@ task Classify {
         ~{"--host-taxids " + hostTaxIDs} \
         ~{"--exclude-taxids " + excludeTaxIDs} \
         ~{"-x " + indexPrefix} \
-        ~{true="-1 " false="-U " defined(read2)} ~{sep="," read1} \
-        ~{"-2 "} ~{sep="," read2} \
+        ~{true="-1" false="-U" length(read2) > 0} ~{sep="," read1} \
+        ~{true="-2" false="" length(read2) > 0} ~{sep="," read2} \
         ~{"-S " + outputPrefix + "/" + outputName + "_classification.tsv"} \
         ~{"--report-file " + outputPrefix + "/" + outputName + "_output_report.tsv"}
     }


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.md
