### PR TITLE
Combine reorderedGlobbedScatters and scatterRegions. Add pedigree input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ that users understand how the changes affect the new version.
 
 version 2.2.0-dev
 ---------------------------
++ Add pedigree input for HaplotypeCaller and GenotypeGVCFs.
++ Combined biopet.ScatterRegions and biopet.ReorderedGlobbedScatters into one.
+  biopet.ScatterRegions now always returns correctly ordered scatters.
 + Add tasks for umi-tools dedup and extract.
 + Add `GenomicsDBImport` task for GATK.
 + Add `annotationGroups` input to `GenotypeGVCFs` to allow setting multiple 

--- a/biopet/biopet.wdl
+++ b/biopet/biopet.wdl
@@ -268,18 +268,13 @@ task ScatterRegions {
         # Glob messes with order of scatters (10 comes before 1), which causes
         # problems at gatherGvcfs
         # Therefore we reorder the scatters with python.
-        # Copy all the scatter files to the CWD so the output matches paths in
-        # the cwd.
-        for file in ~{outputDirPath}/*
-          do cp $file .
-        done
         python << CODE
         import os
         scatters = os.listdir("~{outputDirPath}")
         splitext = [ x.split(".") for x in scatters]
         splitnum = [x.split("-") + [y] for x,y in splitext]
         ordered = sorted(splitnum, key=lambda x: int(x[1]))
-        merged = ["{}-{}.{}".format(x[0],x[1],x[2]) for x in ordered]
+        merged = ["~{outputDirPath}/{}-{}.{}".format(x[0],x[1],x[2]) for x in ordered]
         for x in merged:
           print(x)
         CODE

--- a/gatk.wdl
+++ b/gatk.wdl
@@ -831,7 +831,7 @@ task GenotypeGVCFs {
         annotationGroups: {description: "Which annotation groups will be used for the annotation", category: "advanced"}
         dbsnpVCF: {description: "A dbSNP VCF.", category: "common"}
         dbsnpVCFIndex: {description: "The index for the dbSNP VCF.", category: "common"}
-
+        pedigree: {description: "Pedigree file for determining the population \"founders\"", category: "common"}
         memory: {description: "The amount of memory this job will use.", category: "advanced"}
         javaXmx: {description: "The maximum memory available to the program. Should be lower than `memory` to accommodate JVM overhead.",
                   category: "advanced"}
@@ -957,7 +957,7 @@ task HaplotypeCaller {
         contamination: {description: "Equivalent to HaplotypeCaller's `-contamination` option.", category: "advanced"}
         dbsnpVCF: {description: "A dbSNP VCF.", category: "common"}
         dbsnpVCFIndex: {description: "The index for the dbSNP VCF.", category: "common"}
-
+        pedigree: {description: "Pedigree file for determining the population \"founders\"", category: "common"}
         memory: {description: "The amount of memory this job will use.", category: "advanced"}
         javaXmx: {description: "The maximum memory available to the program. Should be lower than `memory` to accommodate JVM overhead.",
                   category: "advanced"}

--- a/gatk.wdl
+++ b/gatk.wdl
@@ -785,6 +785,7 @@ task GenotypeGVCFs {
         Array[String] annotationGroups = ["StandardAnnotation"]
         File? dbsnpVCF
         File? dbsnpVCFIndex
+        File? pedigree
 
         String memory = "18G"
         String javaXmx = "6G"
@@ -799,6 +800,7 @@ task GenotypeGVCFs {
         -R ~{referenceFasta} \
         -O ~{outputPath} \
         ~{"-D " + dbsnpVCF} \
+        ~{"--pedigree " + pedigree} \
         ~{true="-G" false="" length(annotationGroups) > 0} ~{sep=" -G " annotationGroups} \
         --only-output-calls-starting-in-intervals \
         -V ~{gvcfFile} \

--- a/gatk.wdl
+++ b/gatk.wdl
@@ -903,6 +903,7 @@ task HaplotypeCaller {
         Float? contamination
         File? dbsnpVCF
         File? dbsnpVCFIndex
+        File? pedigree
         Int? ploidy
         Boolean gvcf = false
 
@@ -922,7 +923,8 @@ task HaplotypeCaller {
         ~{"--sample-ploidy " + ploidy} \
         ~{true="-L" false="" defined(intervalList)} ~{sep=' -L ' intervalList} \
         ~{true="-XL" false="" defined(excludeIntervalList)} ~{sep=' -XL ' excludeIntervalList} \
-        ~{"-D" + dbsnpVCF} \
+        ~{"-D " + dbsnpVCF} \
+        ~{"--pedigree " + pedigree} \
         ~{"--contamination-fraction-per-sample-file " + contamination} \
         ~{true="-ERC GVCF" false="" gvcf}
     }


### PR DESCRIPTION
This will make it much easier and more efficient to scatter, since only one job is required now.

Using pedigrees for variantcalling is especially relevant when variant calling on trio's. That happens a lot in clinical departments.

### Checklist
- [x] Pull request details were added to CHANGELOG.md
