### PR TITLE
Allow setting --emit-ref-confidence flag on haplotypecaller

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
 
 ### Checklist
 - [ ] Pull request details were added to CHANGELOG.md
+- [ ] `parameter_meta` for each task is up to date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ that users understand how the changes affect the new version.
 
 version 2.2.0-dev
 ---------------------------
-+ Allow setting the `--emit-ref-confidence` flag for HaplotypeCaller
++ Allow setting the `--emit-ref-confidence` flag for HaplotypeCaller.
 + Add `--output-mode` flag to HaplotypeCaller.
 + Added rtg.Format and rtg.VcfEval tasks.
 + Added gatk.SelectVariants and gatk.VariantFiltration tasks. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ that users understand how the changes affect the new version.
 
 version 2.2.0-dev
 ---------------------------
-+ Add `--output-mode` flag to haplotypecaller.
++ Allow setting the `--emit-ref-confidence` flag for HaplotypeCaller
++ Add `--output-mode` flag to HaplotypeCaller.
 + Added rtg.Format and rtg.VcfEval tasks.
 + Added gatk.SelectVariants and gatk.VariantFiltration tasks. 
 + Fixed a bug where the output directory was not created for bwa.Kit.

--- a/gatk.wdl
+++ b/gatk.wdl
@@ -960,6 +960,8 @@ task HaplotypeCaller {
         contamination: {description: "Equivalent to HaplotypeCaller's `-contamination` option.", category: "advanced"}
         outputMode: {description: "Specifies which type of calls we should output. Same as HaplotypeCaller's `--output-mode` option.",
                      category: "advanced"}
+        emitRefConfidence: {description: "Whether to include reference calls. Three modes: 'NONE', 'BP_RESOLUTION' and 'GVCF'",
+                            category: "advanced"}
         dbsnpVCF: {description: "A dbSNP VCF.", category: "common"}
         dbsnpVCFIndex: {description: "The index for the dbSNP VCF.", category: "common"}
         pedigree: {description: "Pedigree file for determining the population \"founders\"", category: "common"}


### PR DESCRIPTION
I need this for a project where I need to call al sites. I have to use the `BP_RESOLUTION` mode. So I have added this as a possiblity to the task.

### Checklist
- [X] Pull request details were added to CHANGELOG.md
