### PR TITLE
Add pbmm2, the PacBio wrapper for minimap2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ that users understand how the changes affect the new version.
 
 version 4.0.0-develop
 ---------------------------
++ Add tasks for pbmm2, the PacBio wrapper for minimap2.
 + Update the image for chunked-scatter and make use of new features from 0.2.0.
 + Tuned resource requirements for GATK VariantEval, MultiQC, Picard metrics and 
   STAR.

--- a/pbmm2.wdl
+++ b/pbmm2.wdl
@@ -1,0 +1,74 @@
+version 1.0
+
+# Copyright (c) 2020 Leiden University Medical Center
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+task Mapping {
+    input {
+        String presetOption
+        Boolean sort=true
+        String sample
+        File referenceMMI
+        File queryFile
+
+        Int cores = 4
+        String memory = "30G"
+        Int timeMinutes = 1 + ceil(size(queryFile, "G") * 200 / cores)
+        String dockerImage = "quay.io/biocontainers/pbmm2:1.3.0--h56fc30b_1"
+    }
+
+    command {
+        set -e
+        pbmm2 align \
+        --preset ~{presetOption} \
+        ~{true="--sort" false="" sort} \
+        -j ~{cores} \
+        ~{referenceMMI} \
+        ~{queryFile} \
+        ~{sample}.align.bam
+
+    }
+
+    output {
+        File outputAlignmentFile = sample + ".align.bam"
+    }
+
+    runtime {
+        cpu: cores
+        memory: memory
+        time_minutes: timeMinutes
+        docker: dockerImage
+    }
+
+    parameter_meta {
+        presetOption: {description: "This option applies multiple options at the same time.", category: "required"}
+        sort: {description: "Sort the output bam file.", category: "advanced"}
+        sample: {description: "Name of the sample"}
+        referenceMMI: {description: "MMI file for the reference.", category: "required"}
+        queryFile: {description: "BAM file with reads to align against the reference.", category: "required"}
+        cores: {description: "The number of cores to be used.", category: "advanced"}
+        memory: {description: "The amount of memory available to the job.", category: "advanced"}
+        timeMinutes: {description: "The maximum amount of time the job will run in minutes.", category: "advanced"}
+        dockerImage: {description: "The docker image used for this task. Changing this may result in errors which the developers may choose not to address.", category: "advanced"}
+
+        # output
+        outputAlignmentFile: {description: "Mapped bam files."}
+    }
+}

--- a/pbmm2.wdl
+++ b/pbmm2.wdl
@@ -35,7 +35,6 @@ task Mapping {
     }
 
     command {
-        set -e
         pbmm2 align \
         --preset ~{presetOption} \
         ~{true="--sort" false="" sort} \
@@ -43,11 +42,11 @@ task Mapping {
         ~{referenceMMI} \
         ~{queryFile} \
         ~{sample}.align.bam
-
     }
 
     output {
         File outputAlignmentFile = sample + ".align.bam"
+        File outputIndexFile = sample + ".align.bam.bai"
     }
 
     runtime {
@@ -69,6 +68,7 @@ task Mapping {
         dockerImage: {description: "The docker image used for this task. Changing this may result in errors which the developers may choose not to address.", category: "advanced"}
 
         # output
-        outputAlignmentFile: {description: "Mapped bam files."}
+        outputAlignmentFile: {description: "Mapped bam file."}
+        outputIndexFile: {description: "Bam index file."}
     }
 }


### PR DESCRIPTION
See https://github.com/PacificBiosciences/pbmm2 for details. PacBio's wrapper for minimap2 can do bam input/output (so no converting to fastq), and also sort the output bam file on the fly, saving IO and run time.


### Checklist
- [x] Pull request details were added to CHANGELOG.md
- [x] `parameter_meta` for each task is up to date.
