### PR TITLE
Move pacbio-merge image to quay.io

### DIFF
--- a/pacbio.wdl
+++ b/pacbio.wdl
@@ -26,7 +26,7 @@ task mergePacBio {
         String outputPathMergedReport
 
         String memory = "4G"
-        String dockerImage = "lumc/pacbio-merge:0.2"
+        String dockerImage = "quay.io/redmar_van_den_berg/pacbio-merge:0.2"
     }
 
     command {


### PR DESCRIPTION
Docker hub has started to remove unused images from free accounts, which
means that it might remove images used by this pipeline without notice.
Therefore the pipeline now exclusively uses images from quay.io or
official repositories from docker hub, which do not have this
limitation.

### Checklist
- [x] Pull request details were added to CHANGELOG.md.
- [x] Documentation was updated (if required).
- [x] `parameter_meta` was added/updated (if required).
