### PR TITLE
Fallback to copying when hardlinking does not work

### DIFF
--- a/samtools.wdl
+++ b/samtools.wdl
@@ -332,7 +332,7 @@ task Index {
         if [ ! -f ~{outputPath} ]
         then
             mkdir -p "$(dirname ~{outputPath})"
-            ln ~{bamFile} ~{outputPath}
+            ln ~{bamFile} ~{outputPath} || cp ~{bamFile} ~{outputPath}
         fi
         samtools index ~{outputPath} ~{bamIndexPath}
         '
@@ -531,7 +531,7 @@ task Tabix {
         mkdir -p "$(dirname ~{outputFilePath})"
         if [ ! -f ~{outputFilePath} ]
         then
-            ln ~{inputFile} ~{outputFilePath}
+            ln ~{inputFile} ~{outputFilePath} || cp ~{inputFile} ~{outputFilePath}
         fi
         tabix ~{outputFilePath} -p ~{type}
     }


### PR DESCRIPTION
Hardlinking works well in the cromwell implementation, but not in the miniwdl implementation. So use copying as a fallback.

### Checklist
- [ ] Pull request details were added to CHANGELOG.md.
- [ ] Documentation was updated (if required).
- [ ] `parameter_meta` was added/updated (if required).
- [ ] Submodule branches are on develop or a tagged commit.
