### PR TITLE
Use softlink instead of hardlinks for centrifuge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that users understand how the changes affect the new version.
 
 version 5.3.0-dev
 ---------------------------
++ Use softlinks to localise the database for centrifuge.
 + Added the FastqFilter task.
 + Added a new input `revcomp` to cutadapt to set the `--revcomp` flag, defaults to `false`.
 

--- a/centrifuge.wdl
+++ b/centrifuge.wdl
@@ -122,7 +122,7 @@ task Classify {
         indexBasename="$(basename ~{sub(indexFiles[0], "\.[0-9]\.cf", "")})"
         for file in ~{sep=" " indexFiles}
         do
-            ln ${file} $PWD/"$(basename ${file})"
+            ln -s ${file} $PWD/"$(basename ${file})"
         done
         centrifuge \
         ~{inputFormatOptions[inputFormat]} \
@@ -199,7 +199,7 @@ task Inspect {
         indexBasename="$(basename ~{sub(indexFiles[0], "\.[0-9]\.cf", "")})"
         for file in ~{sep=" " indexFiles}
         do
-            ln ${file} $PWD/"$(basename ${file})"
+            ln -s ${file} $PWD/"$(basename ${file})"
         done
         centrifuge-inspect \
         ~{outputOptions[printOption]} \
@@ -256,7 +256,7 @@ task KReport {
         indexBasename="$(basename ~{sub(indexFiles[0], "\.[0-9]\.cf", "")})"
         for file in ~{sep=" " indexFiles}
         do
-            ln ${file} $PWD/"$(basename ${file})"
+            ln -s ${file} $PWD/"$(basename ${file})"
         done
         centrifuge-kreport \
         -x $PWD/${indexBasename} \


### PR DESCRIPTION
If the database files are on a different filesystem then the analysis folder, hardlinks are not allowed, leading to crashes.

### Checklist
- [x] Pull request details were added to CHANGELOG.md.
- [x] Documentation was updated (if required).
- [x] `parameter_meta` was added/updated (if required).
- [x] Submodule branches are on develop or a tagged commit.
