### PR TITLE
Add methylasso, unix.awk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ version 6.0.0-dev
 + Use softlinks to localise the database for centrifuge.
 + Added the FastqFilter task.
 + Added a new input `revcomp` to cutadapt to set the `--revcomp` flag, defaults to `false`.
++ Added a new `unix.Awk` task to enable arbitrary awk transformations of input data.
++ Added `methylasso.Methylasso`, a DMR discovery tool for BiSeq and LR methylation data.
 + Added `samtools.Quickcheck` to allow failing on truncated files early.
 + Fixed bug whereby `samtools.Fastq` could produce out of sync R1/R2 when used with an unsorted bam input. `samtools collate` is now used by default to group reads by readname in order to avoid this issue.
 + New samtools task: split.

--- a/methylasso.wdl
+++ b/methylasso.wdl
@@ -1,0 +1,87 @@
+version 1.0
+
+# Copyright (c) 2017 Leiden University Medical Center
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+task MethyLasso {
+	input {
+		String control_name = "control"
+		Array[File] control
+		String condition_name
+		Array[File] condition
+
+		String outputPrefix = "."
+
+		Int threads = 8
+		String memory = "180G"
+		Int timeMinutes = 6 * 60
+		String dockerImage = "ghcr.io/biowdl/docker-methylasso:sha256-e08c1bedbd0a887e8a76035bc713991e03364dcec9e8b83d7732be55f84dafeb.sig"
+	}
+
+	# Probably will work once we filter for just chr1-22
+	command {
+		set -e
+		mkdir -p '~{outputPrefix}'
+
+		Rscript /methylasso-main/MethyLasso.R \
+			--n1 ~{control_name} \
+			--c1 ~{sep="," control} \
+			--n2 ~{condition_name} \
+			--c2 ~{sep="," condition} \
+			--threads ~{threads} \
+			--meth 4 \
+			--cov 5 \
+			-o '~{outputPrefix}'
+	}
+
+	output {
+		Array[File] comparison_table = glob("~{outputPrefix}/*vs*.tsv")
+		Array[File] comparison_plot = glob("~{outputPrefix}/*vs*.pdf")
+		Array[File] plots = glob("~{outputPrefix}/*.pdf")
+		Array[File] tables = glob("~{outputPrefix}/*.tsv")
+	}
+
+	runtime {
+		cpu: threads
+		memory: memory
+		time_minutes: timeMinutes
+		docker: dockerImage
+	}
+
+	parameter_meta {
+		# inputs
+		control_name: {description: "The name of the control condition.", category: "advanced"}
+		control: {description: "The set of tabular methylation levels in the control condition", category: "required"}
+		condition_name: {description: "The name of the condition being explored.", category: "required"}
+		condition: {description: "The set of tabular methylation levels for the experimental condition.", category: "required"}
+		
+		outputPrefix: {description: "Output directory path + output file prefix.", category: "required"}
+		threads: {description: "The number of threads to use. Only used if the split input is not set.", category: "advanced"}
+		memory: {description: "The amount of memory available to the job.", category: "advanced"}
+		timeMinutes: {description: "The maximum amount of time the job will run in minutes.", category: "advanced"}
+		dockerImage: {description: "The docker image used for this task. Changing this may result in errors which the developers may choose not to address.", category: "advanced"}
+
+		# outputs
+		comparison_table: {description: "Set of comparison tables for results, the main tabular results you're interested in."}
+		comparison_plot: {description: "PDF formatted plot of the condition vs control"}
+		plots: {description: "All produced plots, showing mostly methylation level distributions"}
+		tables: {description: "DMR regions: UMRs, LMRs, etc."}
+	}
+}

--- a/unix.wdl
+++ b/unix.wdl
@@ -66,7 +66,6 @@ task Awk {
 		
 		outputPrefix: {description: "Output directory path + output file prefix.", category: "required"}
 		threads: {description: "The number of threads to use. Only used if the split input is not set.", category: "advanced"}
-		memory: {description: "The amount of memory available to the job.", category: "advanced"}
 		timeMinutes: {description: "The maximum amount of time the job will run in minutes.", category: "advanced"}
 		dockerImage: {description: "The docker image used for this task. Changing this may result in errors which the developers may choose not to address.", category: "advanced"}
 

--- a/unix.wdl
+++ b/unix.wdl
@@ -52,8 +52,6 @@ task Awk {
 		cpu: threads
 		memory: "1GiB"
 		time_minutes: timeMinutes
-		partition: "short"
-		slurm_partition: "short"
 		docker: dockerImage
 	}
 

--- a/unix.wdl
+++ b/unix.wdl
@@ -1,0 +1,76 @@
+version 1.0
+
+# Copyright (c) 2017 Leiden University Medical Center
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+task Awk {
+	input {
+		File in
+		String outputPrefix = "results.tsv"
+		String awk
+		String? sep
+		Boolean compressedInput = false
+
+		Int threads = 1
+		Int timeMinutes = 10
+		# Contains bwa 0.7.17 bwakit 0.7.17.dev1 and samtools 1.10.
+		String dockerImage = "quay.io/biocontainers/samtools:1.21--h96c455f_1"
+	}
+
+	command {
+		set -e
+		mkdir -p "$(dirname ~{outputPrefix})"
+
+		~{true="zcat" false="cat" compressedInput} ~{in} | \
+			awk ~{"-F " + sep} \
+				'~{awk}' \
+				> ~{outputPrefix}
+	}
+
+	output {
+		File out = outputPrefix
+	}
+
+	runtime {
+		cpu: threads
+		memory: "1GiB"
+		time_minutes: timeMinutes
+		partition: "short"
+		slurm_partition: "short"
+		docker: dockerImage
+	}
+
+	parameter_meta {
+		# inputs
+		in: {description: "Input (tabular) file", category: "required"}
+		awk: {description: "AWK expression to transform the input", category: "required"}
+		sep: {description: "Field separator used in the input file", category: "common"}
+		compressedInput: {description: "Is the input compressed?", category: "common"}
+		
+		outputPrefix: {description: "Output directory path + output file prefix.", category: "required"}
+		threads: {description: "The number of threads to use. Only used if the split input is not set.", category: "advanced"}
+		memory: {description: "The amount of memory available to the job.", category: "advanced"}
+		timeMinutes: {description: "The maximum amount of time the job will run in minutes.", category: "advanced"}
+		dockerImage: {description: "The docker image used for this task. Changing this may result in errors which the developers may choose not to address.", category: "advanced"}
+
+		# outputs
+		out: {description: "Transformed output."}
+	}
+}


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.md.
- [x] Documentation was updated (if required).
- [x] `parameter_meta` was added/updated (if required).
- [x] Submodule branches are on develop or a tagged commit.

The awk task was written because my methylasso inputs needed to be reshaped 
(Namely, subset of columns, and dividing one column by 100.)

- I didn't want to add that to the original pipeline since that format wouldn't be useful elsewhere
- I didn't want to add it to methylasso itself, since there's a chance people reuse this task in the future, I don't want to force a specific file format as input since it's useful for a couple different technologies with differently formatted outputs.
